### PR TITLE
feat: additional security - ask users to provide OTP for one last time before they disable two factor auth

### DIFF
--- a/trpc/routes/twoFactor.ts
+++ b/trpc/routes/twoFactor.ts
@@ -122,11 +122,6 @@ export const twoFactor = createRouter({
         });
       }
 
-      await redis.set(`session:${id}`, {
-        ...sessionStore,
-        mfa: true,
-      });
-
       await redis.set(
         `session:${id}`,
         {


### PR DESCRIPTION
## Changes proposed
For additional security, ask users to provide 2FA OTP code before allowing them to disable 2FA

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

https://user-images.githubusercontent.com/3684236/219575430-0bf9016e-be89-46f0-aa93-997c215e34d1.mp4



<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
