### PR TITLE
fix: removing single filter from table removes all other filters

### DIFF
--- a/components/theme/Table/Filters.tsx
+++ b/components/theme/Table/Filters.tsx
@@ -38,7 +38,7 @@ function FilterPill<T extends RowData>({
             table.resetSorting();
           } else if (filterType === "filter") {
             table.setColumnFilters((updater) => [
-              ...updater.filter((filter) => filter.id !== option.id),
+              ...updater.filter((filter) => filter.value !== option.value),
             ]);
           }
         }}


### PR DESCRIPTION
Fixes # (issue)

When removing a single filter from `<Table />` component removes other applied filters as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
