### PR TITLE
fix: remove `unstable_get_server_session` from trpc create context

### DIFF
--- a/trpc/context.ts
+++ b/trpc/context.ts
@@ -1,9 +1,8 @@
 import { NextApiRequest } from "next";
-import { authOptions } from "@/api/auth/[...nextauth]";
+import { getServerSideSession } from "@/utils/session";
 import { type inferAsyncReturnType } from "@trpc/server";
 import { type CreateNextContextOptions } from "@trpc/server/adapters/next";
 import { type Session } from "next-auth";
-import { unstable_getServerSession } from "next-auth/next";
 import prisma from "@/lib/prisma";
 
 type CreateContextOptions = {
@@ -31,8 +30,7 @@ export const createContextInner = async (opts: CreateContextOptions) => {
 export const createContext = async (opts: CreateNextContextOptions) => {
   const { req, res } = opts;
 
-  // Get the session from the server using the unstable_getServerSession wrapper function
-  const session = await unstable_getServerSession(req, res, authOptions);
+  const session = await getServerSideSession(opts);
 
   return await createContextInner({
     req,


### PR DESCRIPTION
Fixes # (deprecated API)

Removed `unstable_get_server_session` function imported from `next-auth` to create the `trpc` context.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
