### PR TITLE
Removing Audit logs button from settings page

### DIFF
--- a/apps/platform/layouts/Settings.tsx
+++ b/apps/platform/layouts/Settings.tsx
@@ -22,11 +22,6 @@ const Settings: React.FC<Props> = ({ tab, user, children }) => {
       name: "Security",
       href: "/settings/security",
     },
-    {
-      id: "audit",
-      name: "Audit logs",
-      href: "/settings/audits",
-    },
   ];
 
   return (


### PR DESCRIPTION
# Description

Removed Audit logs button option on `Settings` layout to get rid of the button in `/settings` page

Fixes #285

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Login in the application and go to `/settings` page, on the left side of the page check if the button `Audit logs` was removed.

**Test Configuration**:

   - OS with version: Windows 11 Pro 22H2 running WSL2 Ubuntu 22.04.2
   - Browser with version: Mozilla Firefox 111.0
   - SDK / CLI with version: Node.js 18.15.0, Yarn 1.22.19

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I documented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
