### PR TITLE
fix: the conflicts between useState and useEffect

### DIFF
--- a/apps/platform/components/projects/EncryptionSetup.tsx
+++ b/apps/platform/components/projects/EncryptionSetup.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { generateKey } from "@47ng/cloak";
+import useUpdateEffect from "@/hooks/useUpdateEffect";
 import { downloadAsTextFile } from "@/utils/helpers";
 import { trpc } from "@/utils/trpc";
 import { ArrowLeft, ArrowRight, Download } from "lucide-react";
@@ -23,8 +24,8 @@ const EncryptionSetup = ({ ...props }) => {
     encryptionKeys.personal.publicKey ? "uploadKey" : "generateKey",
   );
 
-  useEffect(() => {
-    if (pageState === "uploadKey") {
+  useUpdateEffect(() => {
+    if (pageState === "uploadKey" && !cliModal) {
       setCliModal(true);
     }
   }, [pageState]);

--- a/apps/platform/pages/projects/[slug]/index.tsx
+++ b/apps/platform/pages/projects/[slug]/index.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import useUpdateEffect from "@/hooks/useUpdateEffect";
 import ProjectLayout from "@/layouts/Project";
-import { getServerSideSession } from "@/utils/session";
 import { withAccessControl } from "@/utils/withAccessControl";
 import { Project, UserRole } from "@prisma/client";
 import { EncryptedProjectKey, PublicKey } from "@prisma/client";
@@ -11,7 +11,6 @@ import EncryptionSetup from "@/components/projects/EncryptionSetup";
 import { EnvironmentVariableEditor } from "@/components/projects/EnvironmentVariableEditor";
 import { Button } from "@/components/theme";
 import OpenPGP from "@/lib/encryption/openpgp";
-import prisma from "@/lib/prisma";
 
 /**
  * A functional component that represents a project.
@@ -71,7 +70,7 @@ export const ProjectPage = ({
 
   const [selectedBranch, setSelectedBranch] = useState(defaultBranches[0]);
 
-  useEffect(() => {
+  useUpdateEffect(() => {
     const getPrivateKey = sessionStorage.getItem("privateKey");
 
     if (getPrivateKey) {
@@ -83,9 +82,9 @@ export const ProjectPage = ({
         },
       });
     }
-  }, [encryptionKeys]);
+  }, [encryptionKeys.personal.publicKey]);
 
-  useEffect(() => {
+  useUpdateEffect(() => {
     (async () => {
       const privateKey = encryptionKeys.personal.privateKey;
       const encryptedProjectKey = encryptionKeys.project.encryptedProjectKey;
@@ -97,10 +96,7 @@ export const ProjectPage = ({
         )) as string;
 
         setEncryptionKeys({
-          personal: {
-            ...encryptionKeys.personal,
-          },
-
+          ...encryptionKeys,
           project: {
             ...encryptionKeys.project,
             decryptedProjectKey: decryptedProjectKey,
@@ -108,7 +104,7 @@ export const ProjectPage = ({
         });
       }
     })();
-  }, [encryptionKeys.personal, encryptionKeys.project]);
+  }, [encryptionKeys.project.encryptedProjectKey]);
 
   return (
     <ProjectLayout


### PR DESCRIPTION
# Description

client.js?ab48:1 Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

- MacOS, Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
