### PR TITLE
feat: Add browser confirm for CLI token rotation

### DIFF
--- a/apps/platform/components/integrations/CliSetup.tsx
+++ b/apps/platform/components/integrations/CliSetup.tsx
@@ -59,7 +59,6 @@ const CliSetup = ({ currentProject }: CliProps) => {
   const createOrUpdateCLiToken = async () => {
     const token = randomBytes(32).toString("hex");
     const salt = randomBytes(32).toString("hex");
-    setCli({ ...cli, token });
 
     const { encoded: hashedToken } = (await argon2.hash({
       pass: token,
@@ -67,8 +66,15 @@ const CliSetup = ({ currentProject }: CliProps) => {
     })) as { encoded: string };
 
     if (cli.id) {
-      await updateCliTokenMutation({ hashedToken });
+      const confirm = window.confirm(
+        "Are you sure you want to rotate your CLI token? All previous CLI access will be revoked. This action cannot be undone.",
+      );
+      if (confirm) {
+        setCli({ ...cli, token });
+        await updateCliTokenMutation({ hashedToken });
+      }
     } else {
+      setCli({ ...cli, token });
       await createCliTokenMutation({ hashedToken });
     }
   };


### PR DESCRIPTION
# Description

> Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

This commit adds a browser native confirm dialog to the CLI token rotation process. When the user clicks the "Regenerate CLI token" button, they are presented with a confirmation dialog that warns them that all previous CLI access will be revoked. The user must confirm this action before the token is rotated. This ensures that the user is aware of the consequences of rotating their token and prevents accidental token rotation.

The code has been modified to set the new token only after the user confirms the action. This ensures that the "Regenerate CLI token" button remains visible until the user confirms.

Closes #328

## Type of change

> Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

To manually test the new feature, I did the following:

1. Logged in to my account and opened a project page.
2. Clicked the "Regenerate CLI token" button and saw the confirmation dialog.
3. Confirmed the action and saw that the token was updated.

I also tested the edge case where I canceled the confirmation dialog, and saw that the token was not updated.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I documented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
