### PR TITLE
feat: added version related columns to secrets table

### DIFF
--- a/apps/platform/prisma/migrations/20230412162428_add_parent_id_and_version_to_secrets/migration.sql
+++ b/apps/platform/prisma/migrations/20230412162428_add_parent_id_and_version_to_secrets/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Secret" ADD COLUMN     "parentId" TEXT,
+ADD COLUMN     "version" INTEGER NOT NULL DEFAULT 1;

--- a/apps/platform/prisma/schema.prisma
+++ b/apps/platform/prisma/schema.prisma
@@ -189,6 +189,9 @@ model Secret {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
+  version 	Int @default(1)
+  parentId	String?
+
   userId   String
   branchId String
   branch   Branch @relation(fields: [branchId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
# Description

Added `version` and `parentId` columns to `secrets` table.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
