### PR TITLE
chore: fix edge case where --secure is throwing an errror on cli

### DIFF
--- a/apps/cli/src/commands/privateKey.ts
+++ b/apps/cli/src/commands/privateKey.ts
@@ -52,41 +52,48 @@ export default class PrivateKey extends Command {
     this.log(`Envless CLI ${grey(`${version}`)}`);
 
     if (flags.secure) {
-      await loader.start(`Retriving private key from downloads folder...`);
+      loader.start(`Retriving private key from downloads folder...`);
 
       try {
         pKey = await getPrivateKeyFromDownloadsFolder();
+        loader.stop(`Private key successfully retrieved!`);
+        loader.start(`Storing private key to your system's keychain...`);
+        await savePrivateKeyToKeyStore(pKey);
+        loader.stop(`Private key securely stored to your system's keychain!`);
+
+        loader.start(`Deleting private key from downloads folder...`);
+        await deletePrivateKeyFromDownloadsFolder();
+        loader.stop(`Private key deleted from downloads folder!`);
       } catch (error) {
-        await loader.stop(`Private key 'envless.key' not found!`);
-        triggerCancel();
+        loader.stop(
+          `Private key 'envless.key' not found in downloads folder, checking system's keychain...`,
+        );
+        loader.start(`Checking system's keychain for private key...`);
+        pKey = await getPrivateKeyFromKeyStore();
+
+        if (!pKey || pKey.length === 0) {
+          loader.stop(`Private key not found in your system's keychain`);
+          triggerCancel();
+        }
+
+        loader.stop(
+          `Private key successfully retrieved from system's keychain!`,
+        );
       }
-      await loader.stop(`Private key successfully retrieved!`);
-
-      await loader.start(`Storing private key to your system's keychain...`);
-      await savePrivateKeyToKeyStore(pKey);
-      await loader.stop(
-        `Private key securely stored to your system's keychain!`,
-      );
-
-      await loader.start(`Deleting private key from downloads folder...`);
-      await deletePrivateKeyFromDownloadsFolder();
-      await loader.stop(`Private key deleted from downloads folder!`);
     }
 
     if (flags.copy) {
-      await loader.start(
+      loader.start(
         `Copying private key from system's keychain to your clipboard...`,
       );
       pKey = await getPrivateKeyFromKeyStore();
 
       if (pKey && pKey.length > 0) {
         await ncp.copy(pKey, async () => {
-          await loader.stop(`Private key copied to your clipboard!`);
+          loader.stop(`Private key copied to your clipboard!`);
         });
       } else {
-        loader.stop(
-          `Private key 'envless.key' not found in your system's keychain`,
-        );
+        loader.stop(`Private key not found in your system's keychain`);
         triggerCancel();
       }
     }

--- a/apps/platform/components/branches/CreateBranchModal.tsx
+++ b/apps/platform/components/branches/CreateBranchModal.tsx
@@ -27,7 +27,7 @@ export interface BranchWithNameAndId {
 interface BranchModalProps {
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
-  onSuccessCreation: (branch:Branch) => void;
+  onSuccessCreation: (branch: Branch) => void;
 }
 
 const CreateBranchModal = ({


### PR DESCRIPTION
# Description

`envless private --secure --copy` was throwing an error if `envless.key` did not exist on downloads folder.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

