### PR TITLE
fix: handle paste for all the supported file types

### DIFF
--- a/apps/platform/components/projects/EnvironmentVariableEditor.tsx
+++ b/apps/platform/components/projects/EnvironmentVariableEditor.tsx
@@ -9,7 +9,11 @@ import {
 import { encryptString } from "@47ng/cloak";
 import useSecret from "@/hooks/useSecret";
 import { EnvSecret } from "@/types/index";
-import { parseEnvContent, parseEnvFile } from "@/utils/envParser";
+import {
+  attemptToParseCopiedSecrets,
+  parseEnvContent,
+  parseEnvFile,
+} from "@/utils/envParser";
 import { trpc } from "@/utils/trpc";
 import clsx from "clsx";
 import { repeat } from "lodash";
@@ -68,8 +72,8 @@ export function EnvironmentVariableEditor({ branchId }: { branchId: string }) {
   const handlePaste = async (event: any) => {
     event.preventDefault();
     const content = event.clipboardData.getData("text/plain") as string;
-    const pastedSecrets = await parseEnvContent(
-      "env",
+
+    const pastedSecrets = await attemptToParseCopiedSecrets(
       content,
       decryptedProjectKey,
     );

--- a/apps/platform/utils/envParser.ts
+++ b/apps/platform/utils/envParser.ts
@@ -166,3 +166,42 @@ export const parseEnvContent = async (
 
   return secrets;
 };
+
+export const attemptToParseCopiedSecrets = async (
+  copiedContent: string,
+  decryptedProjectKey: string,
+) => {
+  let parsedContent: EnvSecret[] = [];
+
+  if (parsedContent.length === 0) {
+    try {
+      parsedContent = await parseEnvContent(
+        "json",
+        copiedContent,
+        decryptedProjectKey,
+      );
+    } catch (error) {}
+  }
+
+  if (parsedContent.length === 0) {
+    try {
+      parsedContent = await parseEnvContent(
+        "yml",
+        copiedContent,
+        decryptedProjectKey,
+      );
+    } catch (error) {}
+  }
+
+  if (parsedContent.length === 0) {
+    try {
+      parsedContent = await parseEnvContent(
+        "env",
+        copiedContent,
+        decryptedProjectKey,
+      );
+    } catch (error) {}
+  }
+
+  return parsedContent;
+};


### PR DESCRIPTION
# Description
This PR solves the problem of pasting all the supported file types i.e
- JSON
- Dot ENV
- YAML

Now, pasting all these content is supported.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
