### PR TITLE
feat: secrets versioning

### DIFF
--- a/apps/platform/prisma/migrations/20230424135210_update_secrets_table_for_versioning/migration.sql
+++ b/apps/platform/prisma/migrations/20230424135210_update_secrets_table_for_versioning/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `parentId` on the `Secret` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[originalId]` on the table `Secret` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Secret" DROP COLUMN "parentId",
+ADD COLUMN     "originalId" TEXT,
+ALTER COLUMN "version" SET DEFAULT 0;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Secret_originalId_key" ON "Secret"("originalId");

--- a/apps/platform/prisma/schema.prisma
+++ b/apps/platform/prisma/schema.prisma
@@ -188,13 +188,16 @@ model Secret {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
-  version  Int     @default(1)
-  parentId String?
+  version  Int     @default(0)
+  originalId String? @unique
 
   userId   String
   branchId String
   branch   Branch @relation(fields: [branchId], references: [id], onDelete: Cascade)
   user     User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  original Secret? @relation("OriginalSecretHistory", fields: [originalId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+
+  current Secret? @relation("OriginalSecretHistory")
 
   @@index([userId])
   @@index([branchId])


### PR DESCRIPTION
# Description
This feature includes secrets versioning using `originalId` and `version` columns in `Secret` table:
- [x] Default version is set to 0. 
- [x] Whenever a `key` or `value` is updated a new version of secret will be inserted to the table. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
