### PR TITLE
chore: replace settings column with twoFactorRequired boolean column

### DIFF
--- a/apps/platform/components/projects/Projects.tsx
+++ b/apps/platform/components/projects/Projects.tsx
@@ -15,7 +15,7 @@ const Projects = ({ ...props }) => {
   });
 
   const Card = ({ project }) => {
-    const twoFactorAuth = project.settings.enforce2FA;
+    const twoFactorAuth = project.twoFactorRequired as boolean;
 
     const navigateToProjectDetailPage = () => {
       router.push(`/projects/${project.slug}`);

--- a/apps/platform/models/access.tsx
+++ b/apps/platform/models/access.tsx
@@ -22,6 +22,7 @@ export const accessesWithProject = async ({ userId }: { userId: string }) => {
           name: true,
           slug: true,
           updatedAt: true,
+          twoFactorRequired: true,
         },
       },
     },

--- a/apps/platform/pages/projects/[slug]/settings/index.tsx
+++ b/apps/platform/pages/projects/[slug]/settings/index.tsx
@@ -54,13 +54,13 @@ export const SettingsPage = ({
     });
 
   const submitForm = (values) => {
-    const { name, enforce2FA } = values;
+    const { name, twoFactorRequired } = values;
 
     projectGeneralMutation({
       project: {
         ...currentProject,
         name,
-        enforce2FA,
+        twoFactorRequired,
       },
     });
   };
@@ -106,10 +106,8 @@ export const SettingsPage = ({
                 </label>
 
                 <Toggle
-                  // TODO: - create enforce2fa column instead of adding it to settings
-                  // checked={currentProject.settings?.enforce2FA || false}
-                  checked={false}
-                  name="enforce2FA"
+                  checked={currentProject.twoFactorRequired || false}
+                  name="twoFactorRequired"
                   register={register}
                 />
               </div>

--- a/apps/platform/prisma/migrations/20230426030947_replace_settings_with_two_fa_required/migration.sql
+++ b/apps/platform/prisma/migrations/20230426030947_replace_settings_with_two_fa_required/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `settings` on the `Project` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Project" DROP COLUMN "settings",
+ADD COLUMN     "twoFactorRequired" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/platform/prisma/schema.prisma
+++ b/apps/platform/prisma/schema.prisma
@@ -37,7 +37,7 @@ model Project {
   createdAt           DateTime             @default(now())
   updatedAt           DateTime             @updatedAt
   deletedAt           DateTime?
-  settings            Json                 @default("{}")
+  twoFactorRequired   Boolean              @default(false)
   branches            Branch[]
   access              Access[]
   audits              Audit[]

--- a/apps/platform/trpc/routes/projects.tsx
+++ b/apps/platform/trpc/routes/projects.tsx
@@ -164,25 +164,21 @@ export const projects = createRouter({
         project: z.object({
           name: z.string(),
           id: z.string(),
-          enforce2FA: z.boolean(),
+          twoFactorRequired: z.boolean(),
         }),
       }),
     )
     .mutation(async ({ ctx, input }) => {
       const { prisma } = ctx;
       const { project } = input;
-      const enforce2FA = project.enforce2FA || false;
+      const { name } = project;
+      const twoFactorRequired = project.twoFactorRequired || false;
 
       const updatedProject = await prisma.project.update({
         where: {
           id: project.id,
         },
-        data: {
-          name: project.name,
-          settings: {
-            enforce2FA: project.enforce2FA,
-          },
-        },
+        data: { name, twoFactorRequired },
       });
 
       return updatedProject;


### PR DESCRIPTION
# Description

We currently have `settings` `jsonb` column on our project and this settings only had one record (enforce2FA). This PR replaces that with `twoFactorRequired : boolean` for simplicity.

## Type of change

> Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

