### PR TITLE
fix: use uuid on client side for secrets

### DIFF
--- a/apps/platform/hooks/useSecret.ts
+++ b/apps/platform/hooks/useSecret.ts
@@ -49,7 +49,7 @@ function useSecret({ branchId }: { branchId: string }) {
         );
 
         envSecrets.push({
-          id: secret.id,
+          uuid: secret.uuid,
           encryptedKey: secret.encryptedKey,
           encryptedValue: secret.encryptedValue,
           decryptedKey,

--- a/apps/platform/prisma/migrations/20230430072551_add_uuid_column_to_secrets_table/migration.sql
+++ b/apps/platform/prisma/migrations/20230430072551_add_uuid_column_to_secrets_table/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[uuid]` on the table `Secret` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `uuid` to the `Secret` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Secret" ADD COLUMN     "uuid" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Secret_uuid_key" ON "Secret"("uuid");
+
+-- CreateIndex
+CREATE INDEX "Secret_uuid_idx" ON "Secret"("uuid");

--- a/apps/platform/prisma/schema.prisma
+++ b/apps/platform/prisma/schema.prisma
@@ -186,10 +186,11 @@ model Secret {
   encryptedKey   String
   encryptedValue String
   createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  updatedAt     DateTime @updatedAt
 
   userId   String
   branchId String
+  uuid     String @unique
   branch   Branch @relation(fields: [branchId], references: [id], onDelete: Cascade)
   user     User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -198,6 +199,7 @@ model Secret {
 
   @@index([userId])
   @@index([branchId])
+  @@index([uuid])
 }
 
 model SecretVersion {

--- a/apps/platform/prisma/seeds/secrets.ts
+++ b/apps/platform/prisma/seeds/secrets.ts
@@ -1,6 +1,7 @@
 import { encryptString } from "@47ng/cloak";
 import { PrismaClient } from "@prisma/client";
 import colors from "colors";
+import { randomUUID } from "crypto";
 import fs from "fs";
 import OpenPGP from "../../lib/encryption/openpgp";
 import { SecretType } from "./types";
@@ -15,7 +16,6 @@ const seedSecrets = async (count: number = 10) => {
   if (!pgpPrivateKey) {
     throw new Error("No private key found");
   }
-
   const user = await prisma.user.findUnique({
     where: {
       email: "envless@example.com",
@@ -103,6 +103,7 @@ aB0cD1eF2gH3iJ4kL5mN7oP9qR0sT1uV3wX5yZ7A8bC9dE1fG2h3iJ5k6m8o
           encryptedKey,
           encryptedValue,
           userId: user.id,
+          uuid: randomUUID(),
         } as SecretType);
       });
     }

--- a/apps/platform/prisma/seeds/types.ts
+++ b/apps/platform/prisma/seeds/types.ts
@@ -67,4 +67,5 @@ export type SecretType = {
   projectId: string;
   userId: string;
   branchId: string;
+  uuid: string;
 };

--- a/apps/platform/types/index.d.ts
+++ b/apps/platform/types/index.d.ts
@@ -1,5 +1,5 @@
 export interface EnvSecret {
-  id?: string;
+  uuid: string;
   encryptedKey: string;
   encryptedValue: string;
   hiddenValue: string;

--- a/apps/platform/utils/envParser.ts
+++ b/apps/platform/utils/envParser.ts
@@ -53,6 +53,7 @@ export const parseEnvContent = async (
         );
 
         const secret = {
+          uuid: window.crypto.randomUUID(),
           encryptedKey,
           encryptedValue,
           decryptedKey: key as string,
@@ -87,7 +88,7 @@ export const parseEnvContent = async (
             );
 
             const envSecret = {
-              id: "",
+              uuid: window.crypto.randomUUID(),
               encryptedKey,
               encryptedValue,
               hiddenValue: repeat("*", String(pairs).length),
@@ -140,7 +141,7 @@ export const parseEnvContent = async (
           );
 
           const envSecret = {
-            id: "",
+            uuid: window.crypto.randomUUID(),
             encryptedKey,
             encryptedValue,
             hiddenValue: repeat("*", String(pairs).length),


### PR DESCRIPTION
# Description

Used `uuid` to track newly added secrets on the client side.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
