### PR TITLE
fix: added merge icon to pr hover card

### DIFF
--- a/apps/platform/components/pulls/PullRequestTitleHoverCard.tsx
+++ b/apps/platform/components/pulls/PullRequestTitleHoverCard.tsx
@@ -2,7 +2,12 @@ import Link from "next/link";
 import { ReactNode } from "react";
 import { PullRequestStatus } from "@prisma/client";
 import * as HoverCard from "@radix-ui/react-hover-card";
-import { ArrowLeft, GitPullRequest, GitPullRequestClosed } from "lucide-react";
+import {
+  ArrowLeft,
+  GitMerge,
+  GitPullRequest,
+  GitPullRequestClosed,
+} from "lucide-react";
 
 interface PullRequestHoverCardProps {
   triggerComponent: ReactNode;
@@ -54,6 +59,10 @@ export default function PullRequestTitleHoverCard({
 
                 {pullRequestStatus === PullRequestStatus.closed && (
                   <GitPullRequestClosed className="h-4 w-4 text-red-700" />
+                )}
+
+                {pullRequestStatus === PullRequestStatus.merged && (
+                  <GitMerge className="h-4 w-4 text-indigo-700" />
                 )}
               </div>
 


### PR DESCRIPTION
Fixes # (issue)

We were missing merge icon in the pr hover card when status of pr is hover.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
