### PR TITLE
feat: cli secrets get command

### DIFF
--- a/apps/cli/src/commands/secrets/get.ts
+++ b/apps/cli/src/commands/secrets/get.ts
@@ -1,0 +1,156 @@
+import { outro, spinner } from "@clack/prompts";
+import { Args, Command, Flags, ux } from "@oclif/core";
+import axios from "axios";
+import { bold, cyan, grey, red } from "kleur/colors";
+import { readFromDotEnvless } from "../../lib/dotEnvless";
+import {
+  decryptProjectKey,
+  decryptSecrets,
+  triggerCancel,
+} from "../../lib/helpers";
+import { API_VERSION, LINKS } from "../../lib/helpers";
+import { getCliConfigFromKeyStore } from "../../lib/keyStore";
+
+const loader = spinner();
+
+type EncryptedSecret = {
+  id: string;
+  encryptedKey: string;
+  encryptedValue: string;
+};
+
+type SecretResponse = {
+  encryptedSecrets: EncryptedSecret[];
+  encryptedProjectKey: string;
+};
+
+export default class GetSecrets extends Command {
+  static description = `Get All the remote secrets for the current branch`;
+
+  static strict = false;
+
+  static examples = [
+    `
+      $ envless secrets get NODE_ENV
+      $ envless secrets get NODE_ENV REDIS_URL
+    `,
+  ];
+
+  static flags = {
+    help: Flags.string({
+      description: "Show help for the secrets command",
+      char: "h",
+    }),
+
+    id: Flags.string({
+      description: "Unique identifier for CLI",
+      char: "i",
+    }),
+
+    token: Flags.string({
+      description: "Unique CLI token for authentication",
+      char: "t",
+    }),
+    branch: Flags.string({
+      char: "b",
+      description: "Envless project's branch name",
+      default: "development",
+    }),
+  };
+
+  static args = {
+    keys: Args.string({
+      name: "args",
+      description: `Provide key/s, Eg: NODE_ENV REDIS_URL`,
+    }),
+  };
+
+  private async getSecrets(branch: string) {
+    const config = await getCliConfigFromKeyStore();
+
+    const cliId = process.env.ENVLESS_CLI_ID || config?.id;
+    const cliToken = process.env.ENVLESS_CLI_TOKEN || config?.token;
+    const envless = await readFromDotEnvless();
+    const { projectId, branch: branchFromKeyStore } = envless;
+
+    const selectedBranch = branch || branchFromKeyStore;
+
+    loader.start(`Fetching secrets for branch: ${selectedBranch}`);
+
+    if (!cliId || !cliToken) {
+      loader.stop(
+        `Please initialize the Envless CLI first by running ${bold(
+          cyan(`envless init`),
+        )}`,
+      );
+      return;
+    }
+
+    try {
+      const response = await axios.get(
+        `${LINKS.api}/cli/${API_VERSION}/projects/${projectId}/secrets?branch=${selectedBranch}`,
+        {
+          auth: {
+            username: cliId as string,
+            password: cliToken as string,
+          },
+        },
+      );
+
+      const data = response.data as SecretResponse;
+
+      loader.stop(
+        `Fetched ${data.encryptedSecrets.length} secrets for branch: ${selectedBranch}`,
+      );
+
+      if (data.encryptedSecrets.length > 0) {
+        const decryptedProjectKey = await decryptProjectKey(
+          data.encryptedProjectKey,
+        );
+
+        loader.start(`Decrypting ${data.encryptedSecrets.length} secrets`);
+
+        const decryptedSecrets = await decryptSecrets(
+          data.encryptedSecrets,
+          decryptedProjectKey,
+        );
+
+        loader.stop(
+          `Decrypted ${data.encryptedSecrets.length} secrets for branch: ${selectedBranch}`,
+        );
+        return decryptedSecrets;
+      }
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        loader.stop(`${red(err.response?.data?.message)}`);
+      }
+      triggerCancel();
+    }
+  }
+
+  public async run(): Promise<void> {
+    const version = this.config.version;
+    const { flags, argv } = await this.parse(GetSecrets);
+    this.log(`Envless CLI ${grey(`${version}`)}`);
+
+    const decryptedSecrets = await this.getSecrets(flags.branch || "");
+
+    const filteredSecrets = decryptedSecrets?.filter((secret) =>
+      argv.includes(secret?.key),
+    );
+
+    if (filteredSecrets && filteredSecrets?.length > 0) {
+      ux.table(filteredSecrets as never, {
+        key: {
+          header: "Key",
+        },
+        value: {
+          header: "Value",
+        },
+      });
+    } else {
+      outro(`${red("No secrets found with the provided keys")}`);
+    }
+    triggerCancel();
+  }
+}

--- a/apps/platform/components/projects/ProjectCommon.tsx
+++ b/apps/platform/components/projects/ProjectCommon.tsx
@@ -1,9 +1,17 @@
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { Fragment, useEffect, useMemo, useState } from "react";
 import useUpdateEffect from "@/hooks/useUpdateEffect";
 import ProjectLayout from "@/layouts/Project";
 import { useBranchesStore } from "@/store/Branches";
-import type { Branch, EncryptedProjectKey, Project, User, UserPublicKey, UserRole } from "@prisma/client";
+import type {
+  Branch,
+  EncryptedProjectKey,
+  Project,
+  User,
+  UserPublicKey,
+  UserRole,
+} from "@prisma/client";
 import { GitBranch, GitBranchPlus } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { NextSeo } from "next-seo";
@@ -13,7 +21,6 @@ import CreateBranchModal from "../branches/CreateBranchModal";
 import { Button } from "../theme";
 import EncryptionSetup from "./EncryptionSetup";
 import { EnvironmentVariableEditor } from "./EnvironmentVariableEditor";
-import Link from "next/link";
 
 interface PersonalKey {
   publicKey: UserPublicKey["key"];

--- a/apps/platform/pages/projects/[slug]/settings/protected-branch.tsx
+++ b/apps/platform/pages/projects/[slug]/settings/protected-branch.tsx
@@ -193,7 +193,7 @@ export const ProtectedBranch = ({
             selectedBranch={selectedBranch}
             onClick={(branch) => {
               setSelectedBranch(branch);
-              setValue("description", branch.description)
+              setValue("description", branch.description);
             }}
             currentProjectSlug={currentProject.slug}
             full

--- a/apps/platform/pages/projects/[slug]/tree/[branchName].tsx
+++ b/apps/platform/pages/projects/[slug]/tree/[branchName].tsx
@@ -7,9 +7,9 @@ import {
   type EncryptedProjectKey,
   MembershipStatus,
   type Project,
+  User,
   type UserPublicKey,
   UserRole,
-  User,
 } from "@prisma/client";
 import { ProjectCommon } from "@/components/projects/ProjectCommon";
 import OpenPGP from "@/lib/encryption/openpgp";


### PR DESCRIPTION
# Description

This new command `envless secrets get <args>` gets all the secrets and filters out from the args passed.

![image](https://github.com/envless/envless/assets/22125423/2d01452c-fb7d-4785-9916-dc7343e52c1c)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I documented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
