### PR TITLE
fix: make email field on settings page read only

### DIFF
--- a/apps/platform/pages/settings/index.tsx
+++ b/apps/platform/pages/settings/index.tsx
@@ -102,6 +102,7 @@ const AccountSettings: React.FC<DefaultProps> = ({ user }) => {
             register={register}
             errors={errors}
             className="w-full"
+            disabled={true}
             validationSchema={{
               required: "Email address is required",
             }}


### PR DESCRIPTION
# Description
> We will implement email change and verification on next iteration. Scope of this issue is to make it a read-only (disabled) field.

Fixes #474

## Type of change
> Please delete options that are not relevant.

* [x]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also st any relevant details for your test configuration

* [ ]  Test A
* [ ]  Test B

**Test Configuration**:

* OS with version:
* Browser with version:
* SDK / CLI with version:

# Checklist:
* [x]  My code follows the style guidelines of this project
* [ ]  I have performed a self-review of my code
* [ ]  I documented my code, particularly in hard-to-understand areas
* [ ]  I have made corresponding changes to the documentation
* [ ]  My changes generate no new warnings
* [ ]  I have added tests that prove my fix is effective or that my feature works
* [ ]  New and existing unit tests pass locally with my changes
* [ ]  Any dependent changes have been merged and published in downstream modules
