### PR TITLE
fix: empty email not allowed in account settings while disabled

### DIFF
--- a/apps/platform/pages/settings/index.tsx
+++ b/apps/platform/pages/settings/index.tsx
@@ -103,9 +103,9 @@ const AccountSettings: React.FC<DefaultProps> = ({ user }) => {
             errors={errors}
             className="w-full"
             disabled={true}
-            validationSchema={{
-              required: "Email address is required",
-            }}
+            // validationSchema={{
+            //   required: "Email address is required",
+            // }}
           />
 
           <div className="border-dark mb-6 rounded border-2 p-3">


### PR DESCRIPTION
# Description

Email field in account settings did not allow to save it with empty value, while being disabled. 

Fixes # (issue)

## Type of change

> Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- OS with version:
- Browser with version:
- SDK / CLI with version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [ ] I documented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
