### PR TITLE
fix: tooltip overflow hidden, needless horizontal scroll/protected-br…

### DIFF
--- a/apps/platform/components/theme/Table/Table.tsx
+++ b/apps/platform/components/theme/Table/Table.tsx
@@ -27,6 +27,7 @@ interface TableProps<T extends object> {
   data: T[];
   hasFilters?: boolean;
   variant?: "dark" | "darker";
+  overflow?: "overflow-visible" | "overflow-x-auto";
   columns: ColumnDef<T>[];
   visibleColumns?: VisibilityState | undefined;
   filterOptions?: FilterOptions;
@@ -43,6 +44,7 @@ export function Table<T extends object>({
   visibleColumns = {},
   hasFilters = true,
   variant = "dark",
+  overflow = "overflow-x-auto",
   data,
   columns,
   filterOptions,
@@ -115,7 +117,7 @@ export function Table<T extends object>({
             </div>
           </div>
         ) : (
-          <div className="w-full overflow-x-auto">
+          <div className={clsx("w-full", overflow)}>
             <table className="divide-light min-w-full divide-y">
               <tbody
                 className={clsx({

--- a/apps/platform/pages/projects/[slug]/settings/protected-branch.tsx
+++ b/apps/platform/pages/projects/[slug]/settings/protected-branch.tsx
@@ -237,6 +237,7 @@ export const ProtectedBranch = ({
               icon: ShieldCheck,
               actionText: "",
             }}
+            overflow="overflow-visible"
             hasFilters={false}
           />
         </div>


### PR DESCRIPTION
# Description

Fixes #510, namely, the tooltip overflow was hidden, now it shows. The table had a horizontal scroll bar visible even when the data within the table did not exceed its boundaries. To address this, the overflow style was modified to "visible.".

## Type of change

> Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- OS with version:
- Browser with version:
- SDK / CLI with version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I documented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
